### PR TITLE
Add animated poultry header with overflow actions

### DIFF
--- a/app/src/main/java/com/example/data_collect/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/example/data_collect/ui/home/MainScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -67,22 +65,13 @@ fun MainScreen(
             .fillMaxSize()
             .padding(horizontal = 16.dp)
     ) {
-        TopAppBar(
-            title = { Text(text = "🐔 Poultry Data (Compose Demo)") },
-            actions = {
-                TextButton(onClick = {
-                    onSync()
-                    Toast.makeText(context, "Sync simulated", Toast.LENGTH_SHORT).show()
-                }) {
-                    Text("Sync")
-                }
-                TextButton(onClick = onExport) {
-                    Text("Export")
-                }
-                TextButton(onClick = onImport) {
-                    Text("Import")
-                }
-            }
+        PoultryTopBar(
+            onSync = {
+                onSync()
+                Toast.makeText(context, "Sync simulated", Toast.LENGTH_SHORT).show()
+            },
+            onExport = onExport,
+            onImport = onImport
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
+++ b/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PoultryTopBar(
     onSync: () -> Unit,

--- a/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
+++ b/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
@@ -3,8 +3,8 @@ package com.example.data_collect.ui.home
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -50,8 +50,8 @@ fun PoultryTopBar(
 
         AnimatedVisibility(
             visible = expanded,
-            enter = slideInVertically { -it } + fadeIn(),
-            exit  = slideOutVertically { -it } + fadeOut()
+            enter = slideInHorizontally { -it } + fadeIn(),
+            exit  = slideOutHorizontally { -it } + fadeOut()
         ) {
             Row(
                 Modifier

--- a/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
+++ b/app/src/main/java/com/example/data_collect/ui/home/PoultryTopBar.kt
@@ -1,0 +1,90 @@
+package com.example.data_collect.ui.home
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PoultryTopBar(
+    onSync: () -> Unit,
+    onExport: () -> Unit,
+    onImport: () -> Unit
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    Column(Modifier.fillMaxWidth()) {
+        TopAppBar(
+            title = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Image(
+                        painter = painterResource(id = com.example.data_collect.R.drawable.ic_launcher_background),
+                        contentDescription = null,
+                        modifier = Modifier.size(28.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Poultry Data")
+                }
+            },
+            actions = {
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(imageVector = Icons.Filled.MoreVert, contentDescription = "Menu")
+                }
+            }
+        )
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = slideInVertically { -it } + fadeIn(),
+            exit  = slideOutVertically { -it } + fadeOut()
+        ) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                val shape = RoundedCornerShape(50)
+                val green = Color(0xFF1E7A3D)
+                ActionChip("Sync", onSync, green, shape)
+                ActionChip("Export", onExport, green, shape)
+                ActionChip("Import", onImport, green, shape)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionChip(
+    label: String,
+    onClick: () -> Unit,
+    container: Color,
+    shape: Shape
+) {
+    TextButton(
+        onClick = onClick,
+        shape = shape,
+        colors = ButtonDefaults.textButtonColors(
+            containerColor = container,
+            contentColor = Color.White
+        ),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Text(label)
+    }
+}


### PR DESCRIPTION
## Note
- This is the third attempt , for some reason in the first and second attempt it kept generating the binary files for the 
PoultryTopBar.kt file. i think it has to do with the propmt. I asked it create a png image to add to the UI. I think it has problem creating png. This was what i wanted it to look like.
<img width="1200" height="240" alt="header_collapsed_with_chicken" src="https://github.com/user-attachments/assets/716727b5-2a4f-4baf-bc63-b5110aa69278" />


This is what is looks like after the third attempt 

<img width="346" height="80" alt="Screenshot 2568-10-04 at 8 23 25 PM" src="https://github.com/user-attachments/assets/8b1d0a5b-4251-457e-82a6-d131d9ce1f9d" />

### This is the link to the first and second attempt
https://chatgpt.com/s/cd_68e1c9d3bf6081919e565cda1ab58be6
https://chatgpt.com/s/cd_68e1c106859481918556335deff49e11

## Summary
- add a dedicated PoultryTopBar composable with an animated overflow action row and header image
- integrate the new top bar into MainScreen while preserving existing sync/export/import logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c097d938832abe17d22deb90a311